### PR TITLE
simple dockerization of pretend stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+db:
+  image: postgres
+
+pricing:
+  build: pretend_pricing_service
+  links: 
+    - db
+
+deals:
+  build: pretend_deals_service
+  links: 
+    - pricing
+
+catalog:
+  build: pretend_catalog_service
+
+web:
+  build: pretend_web_app
+  ports:
+    - "8081:80"
+  links:
+    - deals
+    - catalog
+

--- a/pretend_catalog_service/Dockerfile
+++ b/pretend_catalog_service/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.2.3-onbuild
+
+ENV PORT 80
+EXPOSE 80
+
+ENV RACK_ENV      production
+
+CMD ["puma", "-C", "puma.rb"]

--- a/pretend_deals_service/Dockerfile
+++ b/pretend_deals_service/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.2.3-onbuild
+
+ENV PORT 80
+EXPOSE 80
+
+ENV RACK_ENV production
+ENV PRICING_SERVICE_BASE_URL http://pricing/
+
+CMD ["puma", "-C", "puma.rb"]

--- a/pretend_pricing_service/Dockerfile
+++ b/pretend_pricing_service/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.2.3-onbuild
+
+ENV PORT 80
+EXPOSE 80
+
+ENV RACK_ENV      production
+ENV DATABASE_URL  postgres://postgres@db/postgres
+
+CMD ["puma", "-C", "puma.rb"]

--- a/pretend_pricing_service/config.ru
+++ b/pretend_pricing_service/config.ru
@@ -10,13 +10,16 @@ ENV['RACK_ENV'] ||= "development"
 if ENV['RACK_ENV'].downcase == 'development'
   $stdout.sync = true
   puts "running in DEV MODE!"
-  db_url = ENV['DATABASE_URL']
-  max_connections = ENV.fetch('DB_POOL', 5)
-else
+end
+
+if ENV.has_key?('VCAP_SERVICES')
   VCAP_SERVICES = JSON.parse(ENV['VCAP_SERVICES'])
   db_credentials = VCAP_SERVICES["elephantsql"][0]["credentials"]
   db_url = db_credentials["uri"]
   max_connections = db_credentials["max_conns"]
+else
+  db_url = ENV['DATABASE_URL']
+  max_connections = ENV.fetch('DB_POOL', 5)
 end
 
 DB = Sequel.connect(db_url,max_connections:max_connections)

--- a/pretend_web_app/Dockerfile
+++ b/pretend_web_app/Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.2.3-onbuild
+
+ENV PORT 80
+EXPOSE 80
+
+ENV RACK_ENV production
+ENV DEALS_SERVICE_BASE_URL http://deals/
+ENV CATALOG_SERVICE_BASE_URL http://catalog/
+
+CMD ["puma", "-C", "puma.rb"]


### PR DESCRIPTION
A very vanilla docker setup using simple Dockerfiles and docker-compose.

If you already have `docker-compose` installed and set up then a `docker-compose up` in the root of the repo should build and stand up a running app stack fleet in 5 different containers.